### PR TITLE
Improve behavior for older firmware revisions not supporting SSL

### DIFF
--- a/SIM800L.py
+++ b/SIM800L.py
@@ -102,6 +102,7 @@ class Modem(object):
         # Commands dictionary. Not the best approach ever, but works nicely.
         commands = {
                     'modeminfo':  {'string':'ATI', 'timeout':3, 'end': 'OK'},
+                    'fwrevision': {'string':'AT+CGMR', 'timeout':3, 'end': 'OK'},
                     'battery':    {'string':'AT+CBC', 'timeout':3, 'end': 'OK'},
                     'scan':       {'string':'AT+COPS=?', 'timeout':60, 'end': 'OK'},
                     'network':    {'string':'AT+COPS?', 'timeout':3, 'end': 'OK'},


### PR DESCRIPTION
Dear Stefano,

this resolves the issue outlined within #3 where we found SIM800 firmware revisions < R14.00 probably won't support SSL at all.

Using `R14.00` here is pure guesswork. We might adapt that to reality if we learn otherwise.

With kind regards,
Andreas.

cc @ClemensGruber